### PR TITLE
Added shell option to installVueNativeDependency function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,8 @@ function installVueNativeDependency() {
   const commandObj = getVueNativeDependencyPackageInstallationCommand();
   const crnaProjectCreationResponse = spawnSync(
     commandObj.commandName,
-    commandObj.optionsArr
+    commandObj.optionsArr,
+    { shell: true }
   );
   spinner.succeed(
     `Installed ${chalk.green("Vue Native Dependency")} Packages \n`


### PR DESCRIPTION
* Without shell option, this function does not add vue-native dependencies on **Windows** environment.
* This PR resolves https://github.com/GeekyAnts/vue-native-core/issues/14