### PR TITLE
Release tag v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,79 @@
-# Vue Native
+# Vue Native CLI
 
 ## Build Native Mobile apps using Vue
 
 > Vue Native is a wrapper around the APIs of React Native. So, with Vue Native, you can do everything what you can do with React Native.
 
-A basic cli that generates a simple 1 page application with [create-react-native-app](https://github.com/react-community/create-react-native-app),
-[vue-native-core](https://github.com/GeekyAnts/vue-native-core)
+Vue Native CLI is a basic command line interface that generates a simple 1 page application with [Expo](https://docs.expo.io/versions/latest/workflow/expo-cli/), or optionally with [React Native CLI](https://github.com/react-native-community/cli)
 
 ## Installation Prerequisites
-You should have create-react-native-app or react-native-cli installed as a global dependency
-```
-For React Native ClI => npm install react-native-cli -g
-```
-```
-For CRNA => npm install create-react-native-app -g
-```
 
-## Installation:
+Since Vue Native is a wrapper around React Native, to use the CLI, you must have either `expo-cli` or `react-native-cli` installed globally.
 
+To install Expo globally, use the following command:
 ```
 $ npm install -g expo-cli
+```
+
+If you wish to use React Native CLI instead, use the following command to install it globally:
+```
+$ npm install -g react-native-cli
+```
+
+You will also need [Android Studio](https://developer.android.com/studio) / [Xcode](https://developer.apple.com/xcode/) for development.
+
+## Installation
+
+Once the prerequisites have been installed, you are all set to install `vue-native-cli`.
+
+```
 $ npm install -g vue-native-cli
 ```
 
-Generate [CRNA + Vue App](https://github.com/GeekyAnts/vue-native-core) App
+## Usage
+
+### For Expo users
+
+Generate an app with the following command:
 
 ```
 $ vue-native init <projectName>
-
-```
-You can also have default React Native Project using command-line options:
-
-```
-vue-native init <projectName> --no-crna
 ```
 
-## [Demo App](https://github.com/GeekyAnts/KitchenSink-Vue-Native)
+This will create a project folder with the specified name in the current working directory.
 
-## Todo:
+To start the development server, execute the following commands:
 
-* Improve Debugging, tracing, error reporting.
+```
+$ cd <projectName>
+$ npm start
+```
+
+Alternatively, you may use `expo start` to start the development server.
+`expo start --ios` and `expo start --android` can be used to directly start the application on the respective platform emulators.
+
+### For React Native CLI users
+
+Generate an app with the following command:
+
+```
+$ vue-native init <projectName> --no-expo
+```
+
+Once the setup is complete, `cd` into the project directory and start the developement server as follows:
+
+```
+$ cd <projectName>
+$ npm start
+```
+
+You may also use `react-native` commands directly. For example to run the application on an iPhone X simulator (assuming Xcode is installed), run
+
+```
+$ react-native run-ios --simulator "iPhone X"
+```
+
+## Useful links
+
+- [The official Vue Native documentation](https://vue-native.io/docs/installation.html)
+- [The Vue Native KitchenSink app](https://github.com/GeekyAnts/KitchenSink-Vue-Native)

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -292,6 +297,11 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "semver-regex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.0.tgz",
+      "integrity": "sha512-xJqZonbAohJmpogzq1Mx7DB4DT3LO+sG5J4i/rcRyZ527dcUqsTVb5T0vM5gwOBf3KO0v7i94EpbdvwSukJyAQ=="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "commander": "^2.20.0",
+    "lodash.union": "^4.6.0",
     "ora": "^3.4.0",
     "prompt": "^1.0.0",
     "semver-regex": "^3.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -164,6 +164,8 @@ function removeExistingDirectory(directoryName) {
   );
 }
 
+// Get the `sourceExts` from the default metro configuration
+// Returns an array like ['js', 'json', 'ts', 'tsx']
 async function getSourceFileExtensions() {
   const { getDefaultConfig } = require(`${process.cwd()}/node_modules/metro-config/src/index.js`);
   const {
@@ -171,6 +173,7 @@ async function getSourceFileExtensions() {
   } = await getDefaultConfig();
 
   const sourceExts = union(defaultSourceExts, constantObjects.vueFileExtensions);
+  // `sourceExts` now looks like ['js', 'json', 'ts', 'tsx', 'vue']
 
   return sourceExts;
 }
@@ -293,6 +296,10 @@ async function setupVueNativeApp(projectName, cmd, isCrna = false) {
 
     const sourceExts = await getSourceFileExtensions();
 
+    // Modify the app.json file to add `sourceExts`
+    // Adding `sourceExts` to metro.config.js stopped working for certain
+    // versions of Expo
+    // This fixes #23
     expoObj.expo.packagerOpts = {
       config: 'metro.config.js',
       sourceExts: sourceExts,

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const spawnSync = require("child_process").spawnSync;
 const program = require("commander");
 const prompt = require("prompt");
 const ora = require("ora");
+const union = require("lodash.union")
 
 const promptModule = require("./prompt/index");
 const constantObjects = require("./utils/constants");
@@ -101,7 +102,7 @@ function init(projectName, cmd, useExpo) {
   }
 }
 
-function createReactNativeCLIProject(projectName, cmd) {
+async function createReactNativeCLIProject(projectName, cmd) {
   const root = path.resolve(projectName);
   if (fs.existsSync(projectName)) {
     removeExistingDirectory(projectName);
@@ -109,10 +110,10 @@ function createReactNativeCLIProject(projectName, cmd) {
   console.log(chalk.green(`Creating Vue Native project ${chalk.bold(projectName)}\n`));
   createRNProjectSync(projectName, cmd);
   installPackages(projectName, cmd);
-  setupVueNativeApp(projectName, cmd);
+  await setupVueNativeApp(projectName, cmd);
 }
 
-function createExpoProject(projectName, cmd) {
+async function createExpoProject(projectName, cmd) {
   const root = path.resolve(projectName);
   if (fs.existsSync(projectName)) {
     removeExistingDirectory(projectName);
@@ -120,7 +121,7 @@ function createExpoProject(projectName, cmd) {
   console.log(chalk.green(`Creating Vue Native project ${chalk.bold(projectName)}\n`));
   createCrnaProjectSync(projectName, cmd);
   installPackages(projectName, cmd);
-  setupVueNativeApp(projectName, cmd, true);
+  await setupVueNativeApp(projectName, cmd, true);
 }
 
 function createCrnaProjectSync(projectName, cmd) {
@@ -161,6 +162,17 @@ function removeExistingDirectory(directoryName) {
   spinner.succeed(
     chalk.yellow(`Removed pre-existing directory with name ${directoryName}\n`),
   );
+}
+
+async function getSourceFileExtensions() {
+  const { getDefaultConfig } = require(`${process.cwd()}/node_modules/metro-config/src/index.js`);
+  const {
+    resolver: { sourceExts: defaultSourceExts }
+  } = await getDefaultConfig();
+
+  const sourceExts = union(defaultSourceExts, constantObjects.vueFileExtensions);
+
+  return sourceExts;
 }
 
 function installPackages(projectName, cmd) {
@@ -253,7 +265,7 @@ function getVueNativeDevDependencyPackageInstallationCommand() {
   return vueNativePkgInstallationCommand;
 }
 
-function setupVueNativeApp(projectName, cmd, isCrna = false) {
+async function setupVueNativeApp(projectName, cmd, isCrna = false) {
   // process.chdir(projectName);
   const rnCliFile = fs.readFileSync(
     path.resolve(__dirname, "./utils/metro.config.js")
@@ -278,7 +290,14 @@ function setupVueNativeApp(projectName, cmd, isCrna = false) {
   //
   if (isCrna) {
     const expoObj = JSON.parse(fs.readFileSync(path.join(constantObjects.appJsonPath), 'utf8'));
-    expoObj.expo.packagerOpts = { config: 'metro.config.js' };
+
+    const sourceExts = await getSourceFileExtensions();
+
+    expoObj.expo.packagerOpts = {
+      config: 'metro.config.js',
+      sourceExts: sourceExts,
+    };
+
     fs.writeFileSync(
       path.join(constantObjects.appJsonPath),
       JSON.stringify(expoObj, null, 2)

--- a/src/prompt/index.js
+++ b/src/prompt/index.js
@@ -27,7 +27,7 @@ function promptForInvalidProjectName(
   });
 }
 
-function createVueProjectAfterConfirmation(
+async function createVueProjectAfterConfirmation(
   promptObj,
   onSuccessAnswer,
   onFailedAnswer,
@@ -44,11 +44,11 @@ function createVueProjectAfterConfirmation(
     default: "no"
   };
 
-  promptObj.get(property, function(err, result) {
+  promptObj.get(property, async function(err, result) {
     if (result.directoryExistAndContinue[0] === "y") {
-      onSuccessAnswer(name, cmd);
+      await onSuccessAnswer(name, cmd);
     } else {
-      onFailedAnswer();
+      await onFailedAnswer();
     }
   });
 }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,7 +13,9 @@ const constantObject = {
   rnPkgCliFileName: "rn-cli.config.js",
   metroConfigFile: "metro.config.js",
   vueTransformerFileName: "vueTransformerPlugin.js",
-  appVueFileName: "App.vue"
+  appVueFileName: "App.vue",
+  expoAppJSONSourceExtsPath: "expo.packagerOpts.sourceExts",
+  vueFileExtensions: ["vue"],
 };
 
 module.exports = constantObject;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -80,7 +80,7 @@ function getReactNativeCLIifAvailable() {
     ? `${constantObjects.rnPackageName} --version`
     : `${constantObjects.rnPackageName} --version 2>/dev/null`
 
-    try {
+  try {
     // execSync returns a Buffer -> convert to string
     const commandResult = (execSync(processCommand).toString() || "").trim();
     const regexMatches = commandResult.match(semverRegex());


### PR DESCRIPTION
This release contains a fix for Expo apps and updates the readme

### Fixes
- Apps created with Vue Native CLI using `expo-cli@3` would crash on start-up as described in #23, because Expo wouldn’t be able to resolve the main app module in the App.vue file, even though the metro configuration is correctly configured. This release works around this issue by adding the required file extensions to the `app.json` file.

### Improvements
- Updated the README.md file