### PR TITLE
Add prop-types dependency to restore the default project

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,6 +223,7 @@ function getVueNativeDependencyPackageInstallationCommand() {
         "add",
         `${constantObjects.vueNativePackages.vueNativeCore}`,
         `${constantObjects.vueNativePackages.vueNativeHelper}`,
+        `${constantObjects.vueNativePackages.propTypes}`,
         "--exact"
       ]
     };
@@ -233,6 +234,7 @@ function getVueNativeDependencyPackageInstallationCommand() {
         "install",
         `${constantObjects.vueNativePackages.vueNativeCore}`,
         `${constantObjects.vueNativePackages.vueNativeHelper}`,
+        `${constantObjects.vueNativePackages.propTypes}`,
         "--save"
       ]
     };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,7 +8,8 @@ const constantObject = {
   vueNativePackages: {
     vueNativeCore: "vue-native-core",
     vueNativeHelper: "vue-native-helper",
-    vueNativeScripts: "vue-native-scripts"
+    vueNativeScripts: "vue-native-scripts",
+    propTypes: "prop-types"
   },
   rnPkgCliFileName: "rn-cli.config.js",
   metroConfigFile: "metro.config.js",


### PR DESCRIPTION
Closes #47 

This adds the `prop-types` dependency to ensure the project builds. 